### PR TITLE
enable custom amount of tokens to be generated 

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -19,30 +19,10 @@ $(() => {
     let organiserAddr /* let of type address here */ ;
     let paymasterAddr /* let of type address here */ ;
     let recipientAddr  /* let of type address here */ ;
-    let defaultTickets = [
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7"
-    ];
+    let tokenVal = "0x00000000000000000000000000000000EF6351E10000000000000000F7";
+    let contractAddr = "";
 
-    var ticketproContract = web3.eth.contract([{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"indices","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"},{"name":"recipient","type":"address"}],"name":"passTo","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"indices","type":"uint256[]"}],"name":"transfer","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"getContractAddress","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"tickets","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"},{"name":"recipient","type":"address"}],"name":"spawnPassTo","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"isStormBirdContract","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"pure","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256[]"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"indices","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"}],"name":"trade","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"endContract","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"myBalance","outputs":[{"name":"","type":"uint256[]"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"tickets","type":"uint256[]"}],"name":"loadNewTickets","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"getDecimals","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"pure","type":"function"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"indices","type":"uint256[]"}],"name":"transferFrom","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"inputs":[{"name":"tickets","type":"uint256[]"},{"name":"nameOfContract","type":"string"},{"name":"symbolForContract","type":"string"},{"name":"organiserAddr","type":"address"},{"name":"paymasterAddr","type":"address"},{"name":"recipientAddr","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"payable":false,"stateMutability":"nonpayable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_indices","type":"uint256[]"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_from","type":"address"},{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_indices","type":"uint256[]"}],"name":"TransferFrom","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"seller","type":"address"},{"indexed":false,"name":"indices","type":"uint256[]"},{"indexed":false,"name":"v","type":"uint8"},{"indexed":false,"name":"r","type":"bytes32"},{"indexed":false,"name":"s","type":"bytes32"}],"name":"Trade","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"indices","type":"uint256[]"},{"indexed":false,"name":"v","type":"uint8"},{"indexed":false,"name":"r","type":"bytes32"},{"indexed":false,"name":"s","type":"bytes32"},{"indexed":true,"name":"recipient","type":"address"}],"name":"PassTo","type":"event"}]);
+    let ticketproContract = web3.eth.contract([{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"indices","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"},{"name":"recipient","type":"address"}],"name":"passTo","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"indices","type":"uint256[]"}],"name":"transfer","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"getContractAddress","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"tickets","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"},{"name":"recipient","type":"address"}],"name":"spawnPassTo","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"isStormBirdContract","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"pure","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256[]"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"indices","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"}],"name":"trade","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"endContract","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"myBalance","outputs":[{"name":"","type":"uint256[]"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"tickets","type":"uint256[]"}],"name":"loadNewTickets","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"getDecimals","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"pure","type":"function"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"indices","type":"uint256[]"}],"name":"transferFrom","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"inputs":[{"name":"tickets","type":"uint256[]"},{"name":"nameOfContract","type":"string"},{"name":"symbolForContract","type":"string"},{"name":"organiserAddr","type":"address"},{"name":"paymasterAddr","type":"address"},{"name":"recipientAddr","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"payable":false,"stateMutability":"nonpayable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_indices","type":"uint256[]"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_from","type":"address"},{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_indices","type":"uint256[]"}],"name":"TransferFrom","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"seller","type":"address"},{"indexed":false,"name":"indices","type":"uint256[]"},{"indexed":false,"name":"v","type":"uint8"},{"indexed":false,"name":"r","type":"bytes32"},{"indexed":false,"name":"s","type":"bytes32"}],"name":"Trade","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"indices","type":"uint256[]"},{"indexed":false,"name":"v","type":"uint8"},{"indexed":false,"name":"r","type":"bytes32"},{"indexed":false,"name":"s","type":"bytes32"},{"indexed":true,"name":"recipient","type":"address"}],"name":"PassTo","type":"event"}]);
 
     function initWeb3() {
         //let's assume that coinbase is our account
@@ -51,6 +31,23 @@ $(() => {
         organiserAddr = $("#ownerAddress").val();
         paymasterAddr = address;
         recipientAddr = $("#recipientAddress").val();
+        let numberOfTokens = $("#numberOfTokens").val();
+        if(numberOfTokens == "")
+        {
+            for(let i = 0; i < 20; i++)
+            {
+                tickets.push(tokenVal);
+            }
+        }
+        else
+        {
+            numberOfTokens = parseInt(numberOfTokens);
+            for(let i = 0; i < numberOfTokens; i++)
+            {
+                tickets.push(tokenVal);
+            }
+        }
+
         if(organiserAddr == "") organiserAddr = address;
         if(recipientAddr == "") recipientAddr = address;
         //once initialized, deploy
@@ -94,6 +91,7 @@ $(() => {
                 }
                 if (typeof contract.address !== 'undefined')
                 {
+                    contractAddr = contract.address;
                     alert('Contract mined! address: ' + contract.address + ' transactionHash: ' + contract.transactionHash);
                     //set xcontract button
                     $("#viewOnXContract").show().click(() =>
@@ -104,9 +102,32 @@ $(() => {
                     $("#viewOnEtherscan").show().click(() => {
                         redirectToEtherscan(contract.address);
                     });
+                    $("#addMoreTokens").show();
                 }
             });
     }
+
+    $("#addMoreTokensButton").click(() =>
+    {
+        let contract = ticketproContract.at(contractAddr);
+        let tokens = $("#addMoreTokens").val();
+        let tokensToAdd = [];
+        for(let i = 0; i < tokens; i++)
+        {
+            tokensToAdd.push(tokenVal);
+        }
+        contract.loadNewTickets.sendTransaction(tokensToAdd, (err, data) =>
+        {
+            if(err)
+            {
+                alert(err);
+            }
+            else
+            {
+                alert("Tx submitted: " + data);
+            }
+        })
+    });
 
     function redirectToEtherscan(address)
     {

--- a/bundle.js
+++ b/bundle.js
@@ -32,22 +32,11 @@ $(() => {
         paymasterAddr = address;
         recipientAddr = $("#recipientAddress").val();
         let numberOfTokens = $("#numberOfTokens").val();
-        if(numberOfTokens == "")
+        if(numberOfTokens == "") numberOfTokens = 20; //default 20
+        for(let i = 0; i < numberOfTokens; i++)
         {
-            for(let i = 0; i < 20; i++)
-            {
-                tickets.push(tokenVal);
-            }
+            tickets.push(tokenVal);
         }
-        else
-        {
-            numberOfTokens = parseInt(numberOfTokens);
-            for(let i = 0; i < numberOfTokens; i++)
-            {
-                tickets.push(tokenVal);
-            }
-        }
-
         if(organiserAddr == "") organiserAddr = address;
         if(recipientAddr == "") recipientAddr = address;
         //once initialized, deploy

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
                 <h1 style="font-weight: 600;">ERC875 Token Factory</h1>
                 <br>
                 <h5 style="font-weight:300;">This website lets you create an ERC875 non fungible token contract at the click of a button.
-                By filling out the form below you will be able to create a contract with a name, symbol and 20 stock assets.
+                By filling out the form below you will be able to create a contract with a name, symbol and stock assets.
                 <br>
                 <br>
                 By loading this contract into AlphaWallet, you can also start using,
@@ -48,18 +48,32 @@
                             <label for="ownerAddress" class="col-sm-2 col-form-label">Owner Address</label>
                             <div class="col-sm-10">
                                 <input class="form-control" id="ownerAddress">
-                                <small id="emailHelp" class="form-text text-muted">This key controls the contract.</small>
+                                <small id="addressOwner" class="form-text text-muted">This key controls the contract.</small>
                             </div>
                         </div>
                         <div class="form-group row">
                             <label for="recipientAddress" class="col-sm-2 col-form-label">Recipient Address</label>
                             <div class="col-sm-10">
                                 <input class="form-control" id="recipientAddress">
-                                <small id="emailHelp" class="form-text text-muted">Receives the tokens.</small>
+                                <small id="addressRecipient" class="form-text text-muted">Receives the tokens.</small>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="numberOfTokens" class="col-sm-2 col-form-label">Number of tokens</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" id="numberOfTokens" type="number">
+                                <small id="tokenNo" class="form-text text-muted">Type in the amount of tokens you want to generate (default 20)</small>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="addMoreTokens" class="col-sm-2 col-form-label" style="display: none">Add more tokens</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" id="addMoreTokens" style="display: none" type="number">
+                                <input type="button" class="btn-lg btn btn-danger" id="addMoreTokensButton" value="Add tokens" style="display: none">
                             </div>
                         </div>
                         <br>
-                        <h5>20 Tokens will be generated for you, if owner or recipient address is blank; the node address will be used</h5>
+                        <h5><strong>If owner or recipient address is blank; the node address will be used </strong></h5>
                         <input type="button" class="btn-y btn-xl" id="deploy" value="Deploy Contract">
                         <input type="button" class="btn-lg btn btn-success" id="viewOnXContract" value="Use on xcontract" style="display: none">
                         <input type="button" class="btn-lg btn btn-info" id="viewOnEtherscan" value="View on etherscan" style="display: none">

--- a/index.js
+++ b/index.js
@@ -18,30 +18,10 @@ $(() => {
     let organiserAddr /* let of type address here */ ;
     let paymasterAddr /* let of type address here */ ;
     let recipientAddr  /* let of type address here */ ;
-    let defaultTickets = [
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7",
-        "0x00000000000000000000000000000000EF6351E10000000000000000F7"
-    ];
+    let tokenVal = "0x00000000000000000000000000000000EF6351E10000000000000000F7";
+    let contractAddr = "";
 
-    var ticketproContract = web3.eth.contract([{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"indices","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"},{"name":"recipient","type":"address"}],"name":"passTo","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"indices","type":"uint256[]"}],"name":"transfer","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"getContractAddress","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"tickets","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"},{"name":"recipient","type":"address"}],"name":"spawnPassTo","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"isStormBirdContract","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"pure","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256[]"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"indices","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"}],"name":"trade","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"endContract","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"myBalance","outputs":[{"name":"","type":"uint256[]"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"tickets","type":"uint256[]"}],"name":"loadNewTickets","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"getDecimals","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"pure","type":"function"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"indices","type":"uint256[]"}],"name":"transferFrom","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"inputs":[{"name":"tickets","type":"uint256[]"},{"name":"nameOfContract","type":"string"},{"name":"symbolForContract","type":"string"},{"name":"organiserAddr","type":"address"},{"name":"paymasterAddr","type":"address"},{"name":"recipientAddr","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"payable":false,"stateMutability":"nonpayable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_indices","type":"uint256[]"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_from","type":"address"},{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_indices","type":"uint256[]"}],"name":"TransferFrom","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"seller","type":"address"},{"indexed":false,"name":"indices","type":"uint256[]"},{"indexed":false,"name":"v","type":"uint8"},{"indexed":false,"name":"r","type":"bytes32"},{"indexed":false,"name":"s","type":"bytes32"}],"name":"Trade","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"indices","type":"uint256[]"},{"indexed":false,"name":"v","type":"uint8"},{"indexed":false,"name":"r","type":"bytes32"},{"indexed":false,"name":"s","type":"bytes32"},{"indexed":true,"name":"recipient","type":"address"}],"name":"PassTo","type":"event"}]);
+    let ticketproContract = web3.eth.contract([{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"indices","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"},{"name":"recipient","type":"address"}],"name":"passTo","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"indices","type":"uint256[]"}],"name":"transfer","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"getContractAddress","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"tickets","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"},{"name":"recipient","type":"address"}],"name":"spawnPassTo","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"isStormBirdContract","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"pure","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256[]"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"expiry","type":"uint256"},{"name":"indices","type":"uint256[]"},{"name":"v","type":"uint8"},{"name":"r","type":"bytes32"},{"name":"s","type":"bytes32"}],"name":"trade","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"endContract","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"myBalance","outputs":[{"name":"","type":"uint256[]"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"tickets","type":"uint256[]"}],"name":"loadNewTickets","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"getDecimals","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"pure","type":"function"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"indices","type":"uint256[]"}],"name":"transferFrom","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"inputs":[{"name":"tickets","type":"uint256[]"},{"name":"nameOfContract","type":"string"},{"name":"symbolForContract","type":"string"},{"name":"organiserAddr","type":"address"},{"name":"paymasterAddr","type":"address"},{"name":"recipientAddr","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"payable":false,"stateMutability":"nonpayable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_indices","type":"uint256[]"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_from","type":"address"},{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_indices","type":"uint256[]"}],"name":"TransferFrom","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"seller","type":"address"},{"indexed":false,"name":"indices","type":"uint256[]"},{"indexed":false,"name":"v","type":"uint8"},{"indexed":false,"name":"r","type":"bytes32"},{"indexed":false,"name":"s","type":"bytes32"}],"name":"Trade","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"indices","type":"uint256[]"},{"indexed":false,"name":"v","type":"uint8"},{"indexed":false,"name":"r","type":"bytes32"},{"indexed":false,"name":"s","type":"bytes32"},{"indexed":true,"name":"recipient","type":"address"}],"name":"PassTo","type":"event"}]);
 
     function initWeb3() {
         //let's assume that coinbase is our account
@@ -50,6 +30,23 @@ $(() => {
         organiserAddr = $("#ownerAddress").val();
         paymasterAddr = address;
         recipientAddr = $("#recipientAddress").val();
+        let numberOfTokens = $("#numberOfTokens").val();
+        if(numberOfTokens == "")
+        {
+            for(let i = 0; i < 20; i++)
+            {
+                tickets.push(tokenVal);
+            }
+        }
+        else
+        {
+            numberOfTokens = parseInt(numberOfTokens);
+            for(let i = 0; i < numberOfTokens; i++)
+            {
+                tickets.push(tokenVal);
+            }
+        }
+
         if(organiserAddr == "") organiserAddr = address;
         if(recipientAddr == "") recipientAddr = address;
         //once initialized, deploy
@@ -93,6 +90,7 @@ $(() => {
                 }
                 if (typeof contract.address !== 'undefined')
                 {
+                    contractAddr = contract.address;
                     alert('Contract mined! address: ' + contract.address + ' transactionHash: ' + contract.transactionHash);
                     //set xcontract button
                     $("#viewOnXContract").show().click(() =>
@@ -103,9 +101,32 @@ $(() => {
                     $("#viewOnEtherscan").show().click(() => {
                         redirectToEtherscan(contract.address);
                     });
+                    $("#addMoreTokens").show();
                 }
             });
     }
+
+    $("#addMoreTokensButton").click(() =>
+    {
+        let contract = ticketproContract.at(contractAddr);
+        let tokens = $("#addMoreTokens").val();
+        let tokensToAdd = [];
+        for(let i = 0; i < tokens; i++)
+        {
+            tokensToAdd.push(tokenVal);
+        }
+        contract.loadNewTickets.sendTransaction(tokensToAdd, (err, data) =>
+        {
+            if(err)
+            {
+                alert(err);
+            }
+            else
+            {
+                alert("Tx submitted: " + data);
+            }
+        })
+    });
 
     function redirectToEtherscan(address)
     {

--- a/index.js
+++ b/index.js
@@ -31,22 +31,11 @@ $(() => {
         paymasterAddr = address;
         recipientAddr = $("#recipientAddress").val();
         let numberOfTokens = $("#numberOfTokens").val();
-        if(numberOfTokens == "")
+        if(numberOfTokens == "") numberOfTokens = 20; //default 20
+        for(let i = 0; i < numberOfTokens; i++)
         {
-            for(let i = 0; i < 20; i++)
-            {
-                tickets.push(tokenVal);
-            }
+            tickets.push(tokenVal);
         }
-        else
-        {
-            numberOfTokens = parseInt(numberOfTokens);
-            for(let i = 0; i < numberOfTokens; i++)
-            {
-                tickets.push(tokenVal);
-            }
-        }
-
         if(organiserAddr == "") organiserAddr = address;
         if(recipientAddr == "") recipientAddr = address;
         //once initialized, deploy


### PR DESCRIPTION
For #8 #1 #5, it is not possible to know what the gas limit is however the client (metamask) will inform the user whether they are exceeding the limit of not therefore this is delegated to the client instead. 

Unfortunately, it is a bit difficult to test until it is deployed on the web as metamask won't work with it locally; this can be mitigated by trying it on gh-pages and retroactively pushing any fixes necessary, I will do this quickly after being merged. 
